### PR TITLE
Build system fixes / improvements

### DIFF
--- a/4build/cmake/FindOpenBLAS.cmake
+++ b/4build/cmake/FindOpenBLAS.cmake
@@ -1,0 +1,64 @@
+
+
+SET(Open_BLAS_INCLUDE_SEARCH_PATHS
+  /usr/include
+  /usr/include/openblas
+  /usr/include/openblas-base
+  /usr/local/include
+  /usr/local/include/openblas
+  /usr/local/include/openblas-base
+  /opt/OpenBLAS/include
+  $ENV{OpenBLAS_HOME}
+  $ENV{OpenBLAS_HOME}/include
+)
+
+SET(Open_BLAS_LIB_SEARCH_PATHS
+        /lib/
+        /lib/openblas-base
+        /lib64/
+        /usr/lib
+        /usr/lib/openblas-base
+        /usr/lib64
+        /usr/local/lib
+        /usr/local/lib64
+        /opt/OpenBLAS/lib
+        $ENV{OpenBLAS}cd
+        $ENV{OpenBLAS}/lib
+        $ENV{OpenBLAS_HOME}
+        $ENV{OpenBLAS_HOME}/lib
+ )
+
+FIND_PATH(OpenBLAS_INCLUDE_DIR NAMES cblas.h PATHS ${Open_BLAS_INCLUDE_SEARCH_PATHS})
+FIND_LIBRARY(OpenBLAS_LIB NAMES openblas PATHS ${Open_BLAS_LIB_SEARCH_PATHS})
+
+SET(OpenBLAS_FOUND ON)
+
+#    Check include files
+IF(NOT OpenBLAS_INCLUDE_DIR)
+    SET(OpenBLAS_FOUND OFF)
+    MESSAGE(STATUS "Could not find OpenBLAS include. Turning OpenBLAS_FOUND off")
+ENDIF()
+
+#    Check libraries
+IF(NOT OpenBLAS_LIB)
+    SET(OpenBLAS_FOUND OFF)
+    MESSAGE(STATUS "Could not find OpenBLAS lib. Turning OpenBLAS_FOUND off")
+ENDIF()
+
+IF (OpenBLAS_FOUND)
+  IF (NOT OpenBLAS_FIND_QUIETLY)
+    MESSAGE(STATUS "Found OpenBLAS libraries: ${OpenBLAS_LIB}")
+    MESSAGE(STATUS "Found OpenBLAS include: ${OpenBLAS_INCLUDE_DIR}")
+  ENDIF (NOT OpenBLAS_FIND_QUIETLY)
+ELSE (OpenBLAS_FOUND)
+  IF (OpenBLAS_FIND_REQUIRED)
+    MESSAGE(FATAL_ERROR "Could not find OpenBLAS")
+  ENDIF (OpenBLAS_FIND_REQUIRED)
+ENDIF (OpenBLAS_FOUND)
+
+MARK_AS_ADVANCED(
+    OpenBLAS_INCLUDE_DIR
+    OpenBLAS_LIB
+    OpenBLAS
+)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
     CACHE PATH "Output directory for executables and DLL's.")
 
 # set(CMAKE_C_STANDARD 99)
-list( APPEND CMAKE_C_FLAGS "-std=c99")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 if(APPLE)
-  list( APPEND CMAKE_CXX_FLAGS "-std=c++11 -stdlib=libc++")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -stdlib=libc++")
 else()
-  list( APPEND CMAKE_CXX_FLAGS "-std=c++11")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/4build/cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ include(${CMAKE_SOURCE_DIR}/4build/cmake/CUDA.cmake)
 
 find_package(PythonLibs 2.7 REQUIRED)
 find_package(Numpy REQUIRED)
+find_package(OpenBLAS REQUIRED)
 
 if (APPLE)
   set(CMAKE_MACOSX_RPATH 0)
@@ -103,14 +104,17 @@ target_link_libraries(cycgt cgt)
 # )
 # add_custom_target(gencfiles ALL DEPENDS cgtcorefuns.c)
 
-set(OPENBLAS_LIBRARY ${CMAKE_BINARY_DIR}/OpenBLAS/libopenblas.a)
+if(NOT OpenBLAS_FOUND)
+  set(OPENBLAS_LIBRARY ${CMAKE_BINARY_DIR}/OpenBLAS/libopenblas.a)
 
-add_custom_command(
-  COMMAND 4build/download_and_build_openblas.py ${CMAKE_BINARY_DIR}/OpenBLAS
-  OUTPUT ${OPENBLAS_LIBRARY}
-  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-)
-add_custom_target(openblas ALL DEPENDS ${OPENBLAS_LIBRARY})
+  add_custom_command(
+    COMMAND 4build/download_and_build_openblas.py ${CMAKE_BINARY_DIR}/OpenBLAS
+    OUTPUT ${OPENBLAS_LIBRARY}
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  )
+
+  add_custom_target(openblas ALL DEPENDS ${OPENBLAS_LIBRARY})
+endif()
 
 # add_library(cgtcorefuns SHARED cgtcorefuns.c)
 # add_dependencies(cgtcorefuns openblas) # WHY IS THIS NECESSARY?


### PR DESCRIPTION
I wasn't able to build cgt on my system, so I had to make a couple of modifications to the CMake script:

* I already have OpenBLAS installed. I such a case, cgt should not download and compile OpenBLAS. I added FindOpenBLAS.cmake from the caffe repository and modified the CMake script so that OpenBLAS is only built from scratch if FindOpenBLAS.cmake can't find OpenBLAS on the system
* appending to CMAKE_C_FLAGS/CMAKE_CXX_FLAGS broke the build on my system because it adds a ';' before appending the string. According to the CMake docs, APPEND is meant for lists (not strings), which are sepearted by semicolons in CMake.