### PR TITLE
Make numpy int arrays 64 bit, since windows makes them 32 bit by default.

### DIFF
--- a/cgt/core.py.bak
+++ b/cgt/core.py.bak
@@ -35,8 +35,7 @@ def as_valid_array(x, dtype=None):
     """
     Converts to numpy array and dtype with valid precision
     """
-    if isinstance(x, int): x = np.array(x, 'i8')
-    else: x = np.asarray(x)
+    x = np.asarray(x)
     x = x.astype(Dtype.canon(x.dtype) if dtype is None else dtype)
     return x
 
@@ -1398,7 +1397,7 @@ class Size(Op):
         return "Size{%i}"%self.axis
     def get_py_func(self, input_types):
         def f(reads):
-            return np.array(reads[0].shape[self.axis],'i8')
+            return np.array(reads[0].shape[self.axis])
         return f
     def pullback(self, inputs, output, goutput):
         raise NonDifferentiable


### PR DESCRIPTION
This fixes issue #44 - assertion error (assert newnewnode.typ == orig.typ) on windows systems.